### PR TITLE
add a fix to a docker issue with copying and running a script

### DIFF
--- a/docker/beanstalkd/Dockerfile
+++ b/docker/beanstalkd/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:wheezy
 MAINTAINER Michał Kruczek <mkruczek@pgs-soft.com>
 
 ADD install.sh install.sh
-RUN chmod +x install.sh && ./install.sh && rm install.sh
+RUN chmod +x install.sh && sync && ./install.sh && rm install.sh
 
 EXPOSE 11300
 


### PR DESCRIPTION
there is a known issue with running commands like:
cp <something> install.sh && chmod a+x install.sh && ./install.sh
the solution is to force a 'sync' or a 'sleep 1' after copying the file
